### PR TITLE
fix: remove g modifier on regexp

### DIFF
--- a/src/components/app/v2/index/IndexPanel.tsx
+++ b/src/components/app/v2/index/IndexPanel.tsx
@@ -7,19 +7,19 @@ import '@/components/app/v2/index/IndexPanel.scss';
 const TYPE_LIST = [
   {
     name: null,
-    reg: /不吃饭/g,
+    reg: /不吃饭/,
   },
   {
     name: '自助',
-    reg: /自助/g,
+    reg: /自助/,
   },
   {
     name: '面点',
-    reg: /面/g,
+    reg: /面/,
   },
   {
     name: '简餐',
-    reg: /.*/g,
+    reg: /.*/,
   },
 ];
 function getTitleLabelType(name: string) {


### PR DESCRIPTION
Test use previous target on regexp when regexp was set with g

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**本次 pr 主要影响的范围** (选择至少一项)

- [x] bug修复
- [ ] 特性
- [ ] 代码风格变更
- [ ] 重构
- [ ] 构建工具
- [ ] 其他，并描述:

**本次pr是否进行了破坏性的变更** (选择一项)

- [ ] 是
- [x] 否

如果是简单的描述一下影响的范围或文件路径:

**本次修改包含以下内容:**

- [x] dev 提交
- [ ] 包含或解决某个 issue：（添加对应issue号）
- [ ] test pass
- [ ] lint pass
- [ ] 已经添加新的测试用例或者更新了旧有测试用例
- [ ] 纯粹的测试

如果添加了任何的**新特性**,那么pr必须包含以下内容之一:

- [ ] cz 的同意签名
- [ ] 已经向午饭群描述这样做的理由且使用如下方式（包括但不限于）不记名投票，获得至少35%以上的票数
- [x] admin 开发者

如果是删除**现有特性**，那么pr必须包含以下内容之一：

- [ ] cz 的同意签名
- [ ] 已经向午饭群描述这样做的理由且使用如下方式（包括但不限于）不记名投票，获得至少65%以上的票数
- [x] admin 开发者


**其他信息:**
